### PR TITLE
Prevent default link dragging behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,4 +25,12 @@
     </ul>
     <small>&copy 2025 Alexey Kutepov</small>
   </body>
+  <script>
+    const anchors = document.getElementsByTagName("a");
+      for (let i = 0; i < anchors.length; i++) {
+        anchors[i].addEventListener("dragstart", function (e) {
+          e.preventDefault();
+        });
+      }
+  </script>
 </html>

--- a/main.css
+++ b/main.css
@@ -121,3 +121,13 @@ body:has(.logo:active) a:link,
 body:has(.logo:active) a:visited {
     text-decoration-color: #f43841;
 }
+
+body:has(#title a:hover) .logo {
+    border-radius: 50%;
+}
+
+body:has(#title a:active) .logo {
+    background: #f43841;
+    border-radius: 0%;
+    transform: rotate(45deg);
+}


### PR DESCRIPTION
Fixing the things that really bugged me in the website.

- Made the logo animate when hovering or clicking on the title
	- just like the list below
- Prevent default browser behavior when dragging links.
	- basically remove the weird dragging of text and it still staying active unless un-pressed again.

If people only used Chrome and Safari then the CSS snippet below would have sufficed.
```css
a {
    -webkit-user-drag: none;
}
```
Refer to the [docs here](https://developer.mozilla.org/en-US/docs/Web/CSS/WebKit_Extensions) as to what it does and why.

There is another way of achieving the same result without using the `<script>` tag. However it is more tedious and I personally do not like it. It would essentially means that we would add the below attribute to every `<a>` tag where one would want to prevent the draggability of the anchor element.
```html
<a ondragstart="event.preventDefault()" href="#">lorem ipsum</a>
```

